### PR TITLE
Print colored jest expect assertions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     },
     "dependencies": {
         "@types/node": "*",
+        "chalk": "4.1.2",
         "throat": "^6.0.1"
     },
     "peerDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,9 +44,9 @@ function errorPostprocessor<T extends Function>(t: ExecutionContext, fn: T): T {
 
         // Grab first stack frame, include it in output.
         // t.fail() grabs a frame within this file which is wrong, no good way around it.
-        const stack = error.stack.replace(/^[\S\s]+?\n +at (.+\n)[\S\s]+$/, '$1');
+        const stack = error.stack.replace(/^[\S\s]+?\n +at (.+)(?:\n[\S\s]+)?$/, '$1');
 
-        t.fail(error.matcherResult.message + '\n\n› ' + chalk.grey(stack));
+        t.fail(error.matcherResult.message + '\n\n' + chalk.grey('› ' + stack));
         return;
       }
       delete error?.matcherResult;

--- a/yarn.lock
+++ b/yarn.lock
@@ -296,6 +296,14 @@ cbor@^8.1.0:
   dependencies:
     nofilter "^3.1.0"
 
+chalk@4.1.2, chalk@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -304,14 +312,6 @@ chalk@^2.0.0:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^4.0.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 chalk@^5.2.0:
   version "5.2.0"


### PR DESCRIPTION
Ava renders thrown errors in a verbose style that makes sense for unexpected, unknown errors.  But jest expect() assertions are not mysterious, and they come pre-formatted, pre-colorized.  We can pass their output directly to ava's `t.fail()` as an assertion message, to be logged verbatim.  Much more readable output.